### PR TITLE
Minor bug fix

### DIFF
--- a/ant/one-jar-ant-task.xml
+++ b/ant/one-jar-ant-task.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project>
     <!-- The following property is expected to be overridden by caller -->   
-    <property name="one-jar.dist.dir" value="./dist"/>   
+    <property name="one-jar.dist.dir" value="../ant"/>   
     <property name="one-jar.version" value="0.98"/>
     <property name="one-jar.ant.jar" value="${one-jar.dist.dir}/one-jar-ant-task-${one-jar.version}.jar"/>
     <taskdef name="one-jar" classname="com.simontuffs.onejar.ant.OneJarTask" 


### PR DESCRIPTION
Ce patch corrige le chemin dans **/ant/one-jar-ant-task.xml** afin que la tâche _jar_ du **build.xml** (à la racine) se déroule correctement. Plus particulièrement, il s'agit d'indiquer le chemin du jar **one-jar-ant-task-0.98.jar** pour que la tâche _one-jar_ présente dans **/talismane_fr/build.xml** et **/talismane_trainer_fr/build.xml** fonctionne.

J'ai testé la modification sous Linux (Lubuntu 13.04 64 bits, OpenJDK) et Windows (Windows XP 32 bits, Oracle JDK 7) et dans les deux cas la modification paraît permettre une bonne compilation avec la commande  : ~ _ant jar_.

```
 Commentaire associé au commit :
 Fixed path for one-jar-ant-task-{version}.jar
```
