### PR TITLE
Start sentences at first non space character

### DIFF
--- a/talismane_core/src/main/java/com/joliciel/talismane/sentenceDetector/SentenceDetector.java
+++ b/talismane_core/src/main/java/com/joliciel/talismane/sentenceDetector/SentenceDetector.java
@@ -169,7 +169,7 @@ public class SentenceDetector implements Annotator<AnnotatedText> {
     List<Annotation<RawTextNoSentenceBreakMarker>> noSentenceBreakMarkers = text.getAnnotations(RawTextNoSentenceBreakMarker.class);
 
     Matcher matcher = SentenceDetector.POSSIBLE_BOUNDARIES.matcher(text.getText());
-    List<Integer> possibleBoundaries = new ArrayList<Integer>();
+    List<Integer> possibleBoundaries = new ArrayList<>();
     while (matcher.find()) {
       if (matcher.start() >= text.getAnalysisStart() && matcher.start() < text.getAnalysisEnd()) {
         boolean noSentences = false;
@@ -198,7 +198,7 @@ public class SentenceDetector implements Annotator<AnnotatedText> {
         LOG.trace(" at position: " + possibleBoundary);
       }
 
-      List<FeatureResult<?>> featureResults = new ArrayList<FeatureResult<?>>();
+      List<FeatureResult<?>> featureResults = new ArrayList<>();
       for (SentenceDetectorFeature<?> feature : features) {
         RuntimeEnvironment env = new RuntimeEnvironment();
         FeatureResult<?> featureResult = feature.check(boundary, env);
@@ -242,6 +242,10 @@ public class SentenceDetector implements Annotator<AnnotatedText> {
     List<Annotation<SentenceBoundary>> existingBoundaries = text.getAnnotations(SentenceBoundary.class);
     if (existingBoundaries.size() > 0) {
       lastBoundary = existingBoundaries.get(existingBoundaries.size() - 1).getEnd();
+    }
+    // advance boundary start until a non space character is encountered
+    while (lastBoundary < text.getAnalysisEnd() && Character.isWhitespace(text.getText().charAt(lastBoundary))) {
+      lastBoundary++;
     }
     for (int guessedBoundary : guessedBoundaries) {
       if (guessedBoundary > lastBoundary) {

--- a/talismane_core/src/test/java/com/joliciel/talismane/sentenceDetector/SentenceDetectorTest.java
+++ b/talismane_core/src/test/java/com/joliciel/talismane/sentenceDetector/SentenceDetectorTest.java
@@ -61,9 +61,9 @@ public class SentenceDetectorTest {
     AnnotatedText annotatedText = new AnnotatedText(text, "Before analysis. ".length(), "Before analysis. Hello Mr. Jones. How are you, Mr. Jones?".length());
 
     List<Annotation<RawTextNoSentenceBreakMarker>> noSentenceBreakMarkers = new ArrayList<>();
-    noSentenceBreakMarkers.add(new Annotation<RawTextNoSentenceBreakMarker>("Before analysis. Hello ".length(), "Before analysis. Hello Mr.".length(),
-        new RawTextNoSentenceBreakMarker("me"), labels));
-    noSentenceBreakMarkers.add(new Annotation<RawTextNoSentenceBreakMarker>("Before analysis. Hello Mr. Jones. How are you, ".length(),
+    noSentenceBreakMarkers
+        .add(new Annotation<>("Before analysis. Hello ".length(), "Before analysis. Hello Mr.".length(), new RawTextNoSentenceBreakMarker("me"), labels));
+    noSentenceBreakMarkers.add(new Annotation<>("Before analysis. Hello Mr. Jones. How are you, ".length(),
         "Before analysis. Hello Mr. Jones. How are you, Mr.".length(), new RawTextNoSentenceBreakMarker("me"), labels));
     annotatedText.addAnnotations(noSentenceBreakMarkers);
 
@@ -117,18 +117,18 @@ public class SentenceDetectorTest {
     AnnotatedText annotatedText = new AnnotatedText(text, "Before analysis. ".length(), text.length());
 
     List<Annotation<RawTextNoSentenceBreakMarker>> noSentenceBreakMarkers = new ArrayList<>();
-    noSentenceBreakMarkers.add(new Annotation<RawTextNoSentenceBreakMarker>("Before analysis. Hello ".length(), "Before analysis. Hello Mr.".length(),
-        new RawTextNoSentenceBreakMarker("me"), labels));
-    noSentenceBreakMarkers.add(new Annotation<RawTextNoSentenceBreakMarker>("Before analysis. Hello Mr. Jones\nHow are you, ".length(),
+    noSentenceBreakMarkers
+        .add(new Annotation<>("Before analysis. Hello ".length(), "Before analysis. Hello Mr.".length(), new RawTextNoSentenceBreakMarker("me"), labels));
+    noSentenceBreakMarkers.add(new Annotation<>("Before analysis. Hello Mr. Jones\nHow are you, ".length(),
         "Before analysis. Hello Mr. Jones\nHow are you, Mr.".length(), new RawTextNoSentenceBreakMarker("me"), labels));
     annotatedText.addAnnotations(noSentenceBreakMarkers);
 
     List<Annotation<SentenceBoundary>> existingBoundaries = new ArrayList<>();
-    existingBoundaries.add(new Annotation<SentenceBoundary>("".length(), "Before analysis.".length(), new SentenceBoundary(), labels));
+    existingBoundaries.add(new Annotation<>("".length(), "Before analysis.".length(), new SentenceBoundary(), labels));
     annotatedText.addAnnotations(existingBoundaries);
 
     List<Annotation<RawTextSentenceBreakMarker>> sentenceBreaks = new ArrayList<>();
-    sentenceBreaks.add(new Annotation<RawTextSentenceBreakMarker>("Before analysis. Hello Mr. Jones".length(), "Before analysis. Hello Mr. Jones\n".length(),
+    sentenceBreaks.add(new Annotation<>("Before analysis. Hello Mr. Jones".length(), "Before analysis. Hello Mr. Jones\n".length(),
         new RawTextSentenceBreakMarker("me"), labels));
     annotatedText.addAnnotations(sentenceBreaks);
 
@@ -143,7 +143,7 @@ public class SentenceDetectorTest {
     assertEquals(4, sentenceBoundaries.size());
     assertEquals("".length(), sentenceBoundaries.get(0).getStart());
     assertEquals("Before analysis.".length(), sentenceBoundaries.get(0).getEnd());
-    assertEquals("Before analysis.".length(), sentenceBoundaries.get(1).getStart());
+    assertEquals("Before analysis. ".length(), sentenceBoundaries.get(1).getStart());
     assertEquals("Before analysis. Hello Mr. Jones\n".length(), sentenceBoundaries.get(1).getEnd());
     assertEquals("Before analysis. Hello Mr. Jones\n".length(), sentenceBoundaries.get(2).getStart());
     assertEquals("Before analysis. Hello Mr. Jones\nHow are you, Mr. Jones?".length(), sentenceBoundaries.get(2).getEnd());


### PR DESCRIPTION
Typically, a punctuation mark is often followed by a space (e.g. a
period marking the end of a sentence in English). The sentence following
this punctuation starts immediately after, but we can consider that the
leading spaces are not relevant to the sentence boundary and that they
can be skipped.